### PR TITLE
allow nil regex matches by checking for nil before strip

### DIFF
--- a/lib/braai/context.rb
+++ b/lib/braai/context.rb
@@ -16,7 +16,7 @@ class Braai::Context
         regex = Regexp.new(regex)
         matches = self.template.scan(regex)
         matches.each do |set|
-          set = [set].flatten.map {|m| m.strip}
+          set = [set].flatten.map {|m| m.strip unless m.nil? }
           val = matcher.call(self, set[0], set)
           self.template.gsub!(set[0], val.to_s) if val
         end


### PR DESCRIPTION
Commit checks for nil before stripping matches allowing nil matches to be returned successfully.  Matches should allow nil results as it more accurately reflects a normal regex result set.
