### PR TITLE
Allow a hash to be used as the value in the attributes argument.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     braai (1.2.0)
       activesupport
+      hashie
 
 GEM
   remote: https://rubygems.org/
@@ -10,21 +11,30 @@ GEM
     activesupport (3.2.8)
       i18n (~> 0.6)
       multi_json (~> 1.0)
+    coderay (1.0.8)
     diff-lcs (1.1.3)
+    hashie (1.2.0)
     i18n (0.6.1)
-    multi_json (1.3.6)
+    method_source (0.8.1)
+    multi_json (1.3.7)
+    pry (0.9.10)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.3.1)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
       rspec-mocks (~> 2.11.0)
     rspec-core (2.11.1)
-    rspec-expectations (2.11.2)
+    rspec-expectations (2.11.3)
       diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.2)
+    rspec-mocks (2.11.3)
+    slop (3.3.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   braai!
+  pry
   rspec

--- a/braai.gemspec
+++ b/braai.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency("activesupport")
+  gem.add_dependency("hashie")
 
 end

--- a/lib/braai.rb
+++ b/lib/braai.rb
@@ -1,5 +1,5 @@
 require 'logger'
-require 'active_support/core_ext/hash/indifferent_access'
+require 'hashie'
 require "braai/version"
 require "braai/configuration"
 require "braai/matchers"

--- a/lib/braai.rb
+++ b/lib/braai.rb
@@ -1,5 +1,5 @@
 require 'logger'
-require 'active_support/hash_with_indifferent_access'
+require 'active_support/core_ext/hash/indifferent_access'
 require "braai/version"
 require "braai/configuration"
 require "braai/matchers"

--- a/lib/braai/context.rb
+++ b/lib/braai/context.rb
@@ -5,7 +5,7 @@ class Braai::Context
   attr_accessor :matchers
 
   def initialize(template, matchers, attributes = {})
-    self.attributes = HashWithIndifferentAccess.new(attributes)
+    self.attributes = Hashie::Mash.new(attributes)
     self.template = template.dup
     self.matchers = matchers
   end

--- a/spec/braai/context_spec.rb
+++ b/spec/braai/context_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper.rb'
+
+describe Braai::Context do
+
+  describe '#initialize' do
+
+    it 'allows a hash as the value in an attributes key/value pair' do
+      hash = { foo: 'bar' }
+      context = Braai::Context.new("template", "matchers", { hash: hash })
+      context.attributes[:hash].should eql("foo" => 'bar')
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds support for nested Hashes and Hashie::Mash objects as attribute values within the Context object.  Examples can be seen here:

https://gist.github.com/666ba7c3fe3b7f3ed3ac

I set out to solve the Hashie::Mash problem but opted to add tests for the nested Hash problem instead as it does not add a dependency on Hashie to illustrate that it works.
