### PR TITLE
Use core_ext version of indifferent_access to avoid nested hash errors.

### DIFF
--- a/lib/braai.rb
+++ b/lib/braai.rb
@@ -1,5 +1,5 @@
 require 'logger'
-require 'active_support/hash_with_indifferent_access'
+require "active_support/core_ext/hash/indifferent_access"
 require "braai/version"
 require "braai/configuration"
 require "braai/matchers"

--- a/spec/braai/context_spec.rb
+++ b/spec/braai/context_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper.rb'
+
+describe Braai::Context do
+
+  describe '#initialize' do
+
+    describe 'attributes arguments' do
+
+      it 'allows a nested hash' do
+        context = Braai::Context.new("template", "matchers", { hash: { foo: 'bar' } })
+        context.attributes[:hash].should eql("foo" => 'bar')
+      end
+    end
+  end
+end


### PR DESCRIPTION
ActiveSupport::HashWithIndifferentAccess throws a nested_hash exception if a nested hash is used to initialize a HWIA object.  This commit replaces this version of HWIA with the core_ext version which is more robust.
