### PR TITLE
install base matchers with set_defaults

### DIFF
--- a/lib/braai/matchers.rb
+++ b/lib/braai/matchers.rb
@@ -17,24 +17,32 @@ module Braai::Matchers
   end
 
   def reset!
-    @matchers = {
-      /({{\s*for (\w+) in (\w+)\s*}}(.+?){{\s*\/for\s*}})/im => ->(template, key, matches) {
-        res = []
-        template.attributes[matches[2]].each do |val|
-          res << Braai::Context.new(matches[3], template.matchers, template.attributes.merge(matches[1] => val)).render
-        end
-        res.join("\n")
-      },
-      /({{\s*([\w]+)\.([\w]+)\s*}})/i => ->(template, key, matches) {
-        attr = template.attributes[matches[1]]
-        attr ? attr.send(matches[2]) : nil
-      },
-      /({{\s*([\w]+)\s*}})/i => ->(template, key, matches) {
-        attr = template.attributes[matches.last]
-        attr ? attr.to_s : nil
-      }
+    @matchers = {}
+    set_defaults
+  end
+
+  def set_defaults
+    @matchers ||= {}
+
+    @matchers[/({{\s*for (\w+) in (\w+)\s*}}(.+?){{\s*\/for\s*}})/im] = ->(template, key, matches) {
+      res = []
+      template.attributes[matches[2]].each do |val|
+        res << Braai::Context.new(matches[3], template.matchers, template.attributes.merge(matches[1] => val)).render
+      end
+      res.join("\n")
     }
-    return @matchers
+
+    @matchers[/({{\s*([\w]+)\.([\w]+)\s*}})/i] = ->(template, key, matches) {
+      attr = template.attributes[matches[1]]
+      attr ? attr.send(matches[2]) : nil
+    }
+
+    @matchers[/({{\s*([\w]+)\s*}})/i] = ->(template, key, matches) {
+      attr = template.attributes[matches.last]
+      attr ? attr.to_s : nil
+    }
+
+    @matchers
   end
 
 end

--- a/spec/braai/matchers_spec.rb
+++ b/spec/braai/matchers_spec.rb
@@ -41,13 +41,25 @@ describe Braai::Matchers do
   end
 
   describe 'reset!' do
-    
+
     it "resets the matchers to their original state" do
       matchers.should have(3).matchers
       map("foo") {}
       matchers.should have(4).matchers
       reset!
       matchers.should have(3).matchers
+    end
+
+  end
+
+  describe 'set_defaults' do
+
+    it "installs the three base matchers" do
+      clear!
+      map("foo") {}
+      matchers.should have(1).matchers
+      set_defaults
+      matchers.should have(4).matchers
     end
 
   end


### PR DESCRIPTION
decomposes reset! so that default matchers can be added later (in order to support adding a catch-all matcher)
